### PR TITLE
Feature/minor changes

### DIFF
--- a/Source/SmallMenu/MenuScaleController.cs
+++ b/Source/SmallMenu/MenuScaleController.cs
@@ -2,9 +2,9 @@
 using IPA.Utilities;
 using System;
 using System.ComponentModel;
+using SiraUtil.Logging;
 using UnityEngine;
 using Zenject;
-using Logger = IPA.Logging.Logger;
 
 namespace SmallMenu
 {
@@ -12,7 +12,7 @@ namespace SmallMenu
     {
         private static readonly FieldAccessor<ScreenModeController, ScreenModeData>.Accessor kDefaultModeDataAccessor = FieldAccessor<ScreenModeController, ScreenModeData>.GetAccessor("_defaultModeData");
 
-        private Logger _logger;
+        private SiraLog _logger;
         private Settings _settings;
         private HierarchyManager _hierarchyManager;
         private ScreenModeController _screenModeController;
@@ -20,7 +20,7 @@ namespace SmallMenu
         private Transform _bottomScreen;
 
         [Inject]
-        public void Construct(Logger logger, Settings settings, HierarchyManager hierarchyManager, ScreenModeController screenModeController)
+        public void Construct(SiraLog logger, Settings settings, HierarchyManager hierarchyManager, ScreenModeController screenModeController)
         {
             _logger = logger;
             _settings = settings;

--- a/Source/SmallMenu/Plugin.cs
+++ b/Source/SmallMenu/Plugin.cs
@@ -6,7 +6,7 @@ using SiraUtil.Zenject;
 
 namespace SmallMenu
 {
-    [Plugin(RuntimeOptions.SingleStartInit)]
+    [Plugin(RuntimeOptions.DynamicInit)]
     public class Plugin
     {
         [Init]

--- a/Source/SmallMenu/Plugin.cs
+++ b/Source/SmallMenu/Plugin.cs
@@ -6,7 +6,7 @@ using SiraUtil.Zenject;
 
 namespace SmallMenu
 {
-    [Plugin(RuntimeOptions.DynamicInit)]
+    [Plugin(RuntimeOptions.DynamicInit), NoEnableDisable]
     public class Plugin
     {
         [Init]

--- a/Source/SmallMenu/Plugin.cs
+++ b/Source/SmallMenu/Plugin.cs
@@ -12,7 +12,8 @@ namespace SmallMenu
         [Init]
         public Plugin(Zenjector zenjector, Logger logger, Config config)
         {
-            zenjector.Install<SmallMenuInstaller>(Location.Menu, logger, config.Generated<Settings>());
+            zenjector.UseLogger(logger);
+            zenjector.Install<SmallMenuInstaller>(Location.Menu, config.Generated<Settings>());
         }
     }
 }

--- a/Source/SmallMenu/SmallMenuInstaller.cs
+++ b/Source/SmallMenu/SmallMenuInstaller.cs
@@ -1,23 +1,18 @@
-﻿using System.Reflection;
-using Zenject;
-using Logger = IPA.Logging.Logger;
+﻿using Zenject;
 
 namespace SmallMenu
 {
     internal class SmallMenuInstaller : Installer
     {
-        private readonly Logger _logger;
         private readonly Settings _settings;
 
-        public SmallMenuInstaller(Logger logger, Settings settings)
+        public SmallMenuInstaller(Settings settings)
         {
-            _logger = logger;
             _settings = settings;
         }
 
         public override void InstallBindings()
         {
-            Container.Bind<Logger>().FromInstance(_logger).When(c => c.ObjectType.Assembly == Assembly.GetExecutingAssembly());
             Container.Bind<Settings>().FromInstance(_settings);
             Container.BindInterfacesAndSelfTo<MenuScaleController>().AsSingle().NonLazy();
             Container.BindInterfacesAndSelfTo<SettingsHost>().AsSingle().NonLazy();


### PR DESCRIPTION
This PR just does a few minor changes:

- Switch to SiraLog, no need anymore to use reflection and condtional binding
- Mark mod as DynamicInit, this makes it possible for users to enable/disable the mod on-the-fly at runtime without requiring a game restart.
- Added NoEnableDisable BSIPA attribute, this suppresses the warnings from BSIPA for missing methods that are annotated with OnEnable or OnDisable